### PR TITLE
fix(action): Invalid version reference of GitHub Action example in README

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -75,7 +75,7 @@
               "README.md"
             ],
             "from": "gates@.*",
-            "to": "gates@${nextRelease.version}",
+            "to": "gates@${nextRelease.gitTag}",
             "results": [
               {
                 "file": "README.md",


### PR DESCRIPTION
fixes #45 